### PR TITLE
Fixed pip.installed dependency

### DIFF
--- a/circus/init.sls
+++ b/circus/init.sls
@@ -32,3 +32,4 @@ circus:
     - require:
       - file: {{ circus.conf_dir }}/circus.ini
       - file: circus-init-script
+      - pip: circus


### PR DESCRIPTION
Sometimes the circus service wouldn't start because the pip.installed dependency was being run afterwards.  Added a dependency so now it works reliably.
